### PR TITLE
don't try to flag if no checked comments

### DIFF
--- a/flagcomments.user.js
+++ b/flagcomments.user.js
@@ -43,6 +43,11 @@ $('document').ready(function(){
 	{
 		$(this).html("<strong>working...</strong>");
 		var checked = $('input:checked');
+		if (checked.length == 0){
+			$(".autoflag_checkbox").remove();
+			$(this).html("autoflag");
+			return;
+		}
 		console.log(checked.length);
 		var flaggedcomments=$('.autoflag_checkbox:checked').map(function(){return $(this).parent().attr('id').replace(/comment-/g, "")}).toArray()
 		function flagnext(){


### PR DESCRIPTION
I guess this is another narrow use-case enhancement but without it, the box gets stuck on **working...** when you click **confirm** while no comments are checked :smile: 